### PR TITLE
Add title and url separator for rest vs gql item

### DIFF
--- a/good-references/reference-articles.md
+++ b/good-references/reference-articles.md
@@ -6,7 +6,7 @@ description: A list of really good articles and references
 
 ### **GraphQL**
 
-* Comparison of REST and GraphQL[https://dev.to/sadarshannaiynar/graphql-or-rest-what-should-i-use-38mj](https://dev.to/sadarshannaiynar/graphql-or-rest-what-should-i-use-38mj)
+* Comparison of REST and GraphQL - [https://dev.to/sadarshannaiynar/graphql-or-rest-what-should-i-use-38mj](https://dev.to/sadarshannaiynar/graphql-or-rest-what-should-i-use-38mj)
 
 ### CryptoCurrency
 


### PR DESCRIPTION
Just whitespace... but that one link was unlike the others! 

![pisa fixed](https://i.imgur.com/Pixul0g.jpg)